### PR TITLE
Add hardware monitoring, fix typo

### DIFF
--- a/run-benchmarks.sh
+++ b/run-benchmarks.sh
@@ -115,6 +115,17 @@ function setup {
   cd benchmarks
 }
 
+# Record CPU and memory usage
+function log_hw {
+  echo "1" >> benchmark_active.log
+  echo "%CPU %MEM $(date)" >> ps.log
+  while [ $(tail -n 1 benchmark_active.log) == "1" ]
+  do
+    ps -o pcpu= -o pmem= -C $1 >> ps.log
+    sleep 2
+  done
+}
+
 function run_coremark {
   ## COREMARK
   echo "Running Coremark benchmarks."
@@ -129,7 +140,9 @@ function run_coremark {
   fi
 
   # Run coremark
+  log_hw "coremark.exe" &
   sh run_coremark.sh
+  echo "0" >> benchmark_active.log
 
   # Process results.txt
   if [ $PROCESS_RESULTS != "0" ]; then
@@ -144,7 +157,7 @@ function run_dhrystone {
   ## DHRYSTONE
   echo "Running Dhrystone benchmarks.\n"
   rm -rf dhrystone  # if there is a directory here already, we want it gone.
-  mv ../benchmark_src/dhrystone/ .  # get predownloaded dhrystone source
+  mv benchmark_src/dhrystone/ .  # get predownloaded dhrystone source
   cd dhrystone
 
   # Edit Makefile
@@ -160,7 +173,9 @@ function run_dhrystone {
   # Make and run
   make
   mv ../benchmark_scripts/dhrystone/run_dhrystone.sh run_dhrystone.sh
+  log_hw "gcc_dry2reg" &
   sh run_dhrystone.sh
+  echo "0" >> benchmark_active.log
 
   # Process results.txt
   if [ $PROCESS_RESULTS != "0" ]; then
@@ -175,7 +190,7 @@ function run_whetstone {
   ## WHETSTONE
   echo "Running Whetstone benchmarks."
   rm -rf whetstone  # if there is a directory here already, we want it gone.
-  mv ../benchmark_src/whetstone/ .  # get predownloaded whetstone source
+  mv benchmark_src/whetstone/ .  # get predownloaded whetstone source
   cd whetstone
 
   # Make and then run whetstone
@@ -185,7 +200,9 @@ function run_whetstone {
     gcc whetstone.c -O3 -Ofast -lm -o whetstone
   fi
   mv ../benchmark_scripts/whetstone/run_whetstone.sh run_whetstone.sh
+  log_hw "whetstone" &
   sh run_whetstone.sh
+  echo "0" >> benchmark_active.log
 
   # Process results.txt
   if [ $PROCESS_RESULTS != "0" ]; then
@@ -229,7 +246,7 @@ function main {
   run_dhrystone
   run_whetstone
   echo
-  echo "Benchmarking process complete! Find the results inside of results.txt and results_summary.txt in each folder."
+  echo "Benchmarking process complete! Find the results inside of results.txt and results_summary.txt in each folder. CPU and memory usage are in ps.log in each folder. Note that CPU usage is computed as the percentage of CPU time used over the lifetime of the process."
   echo "Exiting program."
   echo
 }


### PR DESCRIPTION
The %CPU measurement is the current average CPU usage by each benchmarking process.

The `mv ../benchmark_src/whetstone/ .` and `mv ../benchmark_src/dhrystone/ .` commands were wrong for me. I don't see how they could have worked on another machine since the directory structure should be the same, but we can discuss those changes if others disagree.